### PR TITLE
Minute edits to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -54,6 +54,8 @@ class THMBuilder:
             file.truncate()
             file.write(''.join(self.clstext))
 
-thmbuilder = THMBuilder()
-thmbuilder.process_format()
-thmbuilder.build()
+
+if __name__ == "__main__":
+    thmbuilder = THMBuilder()
+    thmbuilder.process_format()
+    thmbuilder.build()

--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 FILE_NAME = 'notex.cls'
 
+
 class THMBuilder:
     def __init__(self):
         with open(FILE_NAME) as file:
@@ -55,7 +56,7 @@ class THMBuilder:
             file.write(''.join(self.clstext))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     thmbuilder = THMBuilder()
     thmbuilder.process_format()
     thmbuilder.build()


### PR DESCRIPTION
Two edits have been made in `build.py`:

1. Code that is executed is put within an `if` statement. Detailed reasons are [here](https://stackoverflow.com/a/419185). In short, the `if` statement makes it so that the code is only executed when `build.py` is directly run in terminal, and not when it is imported as a package.
2. A line is added between the declaration of `FILE_NAME` and the class `THMBuilder`. This is for conformation with the [PEP 8 style guide](https://peps.python.org/pep-0008/#class-names).

These changes should not affect the behavior of `build.py` in any significant way.

Also, thanks for making $\text{No}\TeX$ open source.