### PR TITLE
"rosslogo" as Option for NoTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@
     * `\lecture` will now denote the number of the problem set, making the title `Problem Set #{}`. Additionally, `\psetnum` command will be available as an alias to `\lecture`.
   * Redefines Sections to Problems.
   * Redefines Subsections and Subsubsections resembling those in `amsart` class.
-  * Has an optional Ross Program logo enabled using `\enablerosslogo`.
+  * Has an optional Ross Program logo enabled using the `rosslogo` option.

--- a/notex.cls
+++ b/notex.cls
@@ -157,7 +157,7 @@
 \newcommand{\subheadertitle}[1]{\renewcommand{\defaultsubheader}{#1}}
 \newcommand{\subsubheadertitle}[1]{\renewcommand{\defaultsubsubheader}{#1}}
 
-\newcommand{\enablerosslogo}{
+\newcommand{\enablerosslogo}{% Deprecated: Use the option rosslogo when loading NoTeX.
   \RequirePackage{background}
   \backgroundsetup{
     scale=2.4,

--- a/notex.cls
+++ b/notex.cls
@@ -14,6 +14,7 @@
 \RequirePackage{amsmath}
 \RequirePackage{amsthm}
 \RequirePackage{amssymb}
+\RequirePackage{background}
 \RequirePackage{float}
 \RequirePackage{graphicx}
 \RequirePackage{lipsum}
@@ -165,6 +166,15 @@
     contents={\includegraphics{res/rosslogo.pdf}}
   }
 }
+
+\DeclareOption{rosslogo}{
+  \backgroundsetup{
+  scale=2.4,
+  opacity=0.075,
+  angle=0,
+  contents={\includegraphics{res/rosslogo.pdf}}
+}}
+\ProcessOptions\relax
 
 \newenvironment{legacyproof}{\par
   \pushQED{\qed}

--- a/notex.cls
+++ b/notex.cls
@@ -42,6 +42,10 @@
     linktoc=all
 }
 
+\backgroundsetup{
+  contents=
+}
+
 \definecolor{pgreen}{HTML}{047101}
 \definecolor{pred}{HTML}{FF634D}
 \definecolor{pblue}{HTML}{0376BB}
@@ -169,10 +173,10 @@
 
 \DeclareOption{rosslogo}{
   \backgroundsetup{
-  scale=2.4,
-  opacity=0.075,
-  angle=0,
-  contents={\includegraphics{res/rosslogo.pdf}}
+    scale=2.4,
+    opacity=0.075,
+    angle=0,
+    contents={\includegraphics{res/rosslogo.pdf}}
 }}
 \ProcessOptions\relax
 


### PR DESCRIPTION
I have made `rosslogo` a option for the NoTeX class. This makes enabling the Ross logo somewhat more intuitive and convenient. One who would like to have the Ross logo could simply type:

`\documentclass[12pt, rosslogo]{notex}`

to have the ross logo in their document:

![image](https://github.com/zimoluo/notex/assets/138541097/58fe6c56-bc91-489a-a913-89f74b930730)

However, the package [`background`](https://www.ctan.org/pkg/background) becomes always loaded, in contrast to it being only required whenever `\enablerosslogo` is used. This is done because [`\RequirePackage` cannot be used within `\DeclareOption`](https://tex.stackexchange.com/a/468455). Apart from wasting milliseconds each compile, there should be no problems otherwise.

The command `\enablerosslogo` is kept for compatibility purposes but deprecated.